### PR TITLE
#42: Correct OPmon/tos validation limits

### DIFF
--- a/Tables/MIP_AP3hr.json
+++ b/Tables/MIP_AP3hr.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "AP3hr"
   },
   "variable_entry": {
@@ -51,15 +51,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "clt",
       "positive": "",
       "standard_name": "cloud_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "clwvi": {
       "cell_measures": "area: areacella",
@@ -99,15 +99,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 110.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfls",
       "positive": "up",
       "standard_name": "surface_upward_latent_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2400.0,
-      "valid_min": -800.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hfss": {
       "cell_measures": "area: areacella",
@@ -123,15 +123,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 60.0,
-      "ok_min_mean_abs": 5.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfss",
       "positive": "up",
       "standard_name": "surface_upward_sensible_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2000.0,
-      "valid_min": -1000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "pr": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_AP3hrPt.json
+++ b/Tables/MIP_AP3hrPt.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "AP3hrPt"
   },
   "variable_entry": {
@@ -354,15 +354,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "clt",
       "positive": "",
       "standard_name": "cloud_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "cltc": {
       "cell_measures": "area: areacella",
@@ -474,15 +474,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 110.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfls",
       "positive": "up",
       "standard_name": "surface_upward_latent_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2400.0,
-      "valid_min": -800.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hfss": {
       "cell_measures": "area: areacella",
@@ -498,15 +498,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 60.0,
-      "ok_min_mean_abs": 5.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfss",
       "positive": "up",
       "standard_name": "surface_upward_sensible_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2000.0,
-      "valid_min": -1000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hurs": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_AP6hr.json
+++ b/Tables/MIP_AP6hr.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "AP6hr"
   },
   "variable_entry": {
@@ -132,8 +132,8 @@
       "standard_name": "air_pressure_at_mean_sea_level",
       "type": "real",
       "units": "Pa",
-      "valid_max": 113000.0,
-      "valid_min": 92500.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rv850": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_APday.json
+++ b/Tables/MIP_APday.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "APday"
   },
   "variable_entry": {
@@ -370,15 +370,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "clt",
       "positive": "",
       "standard_name": "cloud_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "cltcalipso": {
       "cell_measures": "area: areacella",
@@ -538,15 +538,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 110.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfls",
       "positive": "up",
       "standard_name": "surface_upward_latent_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 1800.0,
-      "valid_min": -400.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hfmlt": {
       "cell_measures": "area: areacella",
@@ -634,15 +634,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 60.0,
-      "ok_min_mean_abs": 5.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfss",
       "positive": "up",
       "standard_name": "surface_upward_sensible_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2000.0,
-      "valid_min": -1000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hur": {
       "cell_measures": "area: areacella",
@@ -659,15 +659,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hur",
       "positive": "",
       "standard_name": "relative_humidity",
       "type": "real",
       "units": "%",
-      "valid_max": 105.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "hurs": {
       "cell_measures": "area: areacella",
@@ -809,15 +809,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.01,
-      "ok_min_mean_abs": 0.00001,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hus8",
       "positive": "",
       "standard_name": "specific_humidity",
       "type": "real",
       "units": "1",
-      "valid_max": 0.06,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "hus850": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_APfx.json
+++ b/Tables/MIP_APfx.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "APfx"
   },
   "variable_entry": {
@@ -27,15 +27,15 @@
         "atmos",
         "land"
       ],
-      "ok_max_mean_abs": 1000000000000.0,
-      "ok_min_mean_abs": 100000.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "areacella",
       "positive": "",
       "standard_name": "cell_area",
       "type": "real",
       "units": "m2",
-      "valid_max": 1000000000000.0,
-      "valid_min": 100000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "ps": {
       "cell_measures": "area: areacella",
@@ -172,8 +172,8 @@
       "standard_name": "land_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "siltfrac": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_APmon.json
+++ b/Tables/MIP_APmon.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "APmon"
   },
   "variable_entry": {
@@ -51,15 +51,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 100000.0,
-      "ok_min_mean_abs": 5000.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "ccb",
       "positive": "",
       "standard_name": "air_pressure_at_convective_cloud_base",
       "type": "real",
       "units": "Pa",
-      "valid_max": 115000.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "cct": {
       "cell_measures": "area: areacella",
@@ -75,15 +75,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 100000.0,
-      "ok_min_mean_abs": 5000.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "cct",
       "positive": "",
       "standard_name": "air_pressure_at_convective_cloud_top",
       "type": "real",
       "units": "Pa",
-      "valid_max": 115000.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "cfadDbze94": {
       "cell_measures": "area: areacella",
@@ -269,15 +269,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.9,
-      "ok_min_mean_abs": 0.02,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "ci",
       "positive": "",
       "standard_name": "convection_time_fraction",
       "type": "real",
       "units": "1",
-      "valid_max": 1.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "clcalipso": {
       "cell_measures": "area: areacella",
@@ -565,15 +565,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.1187,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "clivi",
       "positive": "",
       "standard_name": "atmosphere_mass_content_of_cloud_ice",
       "type": "real",
       "units": "kg m-2",
-      "valid_max": 1.535,
-      "valid_min": -0.000001872
+      "valid_max": "",
+      "valid_min": ""
     },
     "cllcalipso": {
       "cell_measures": "area: areacella",
@@ -665,15 +665,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "clt",
       "positive": "",
       "standard_name": "cloud_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "cltcalipso": {
       "cell_measures": "area: areacella",
@@ -785,15 +785,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.2846,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "clwvi",
       "positive": "",
       "standard_name": "atmosphere_mass_content_of_cloud_condensed_water",
       "type": "real",
       "units": "kg m-2",
-      "valid_max": 3.364,
-      "valid_min": -0.000003827
+      "valid_max": "",
+      "valid_min": ""
     },
     "clwvic": {
       "cell_measures": "area: areacella",
@@ -1032,8 +1032,8 @@
       "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_emission_from_natural_sources",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.000002,
-      "valid_min": -0.00002
+      "valid_max": "",
+      "valid_min": ""
     },
     "grplmxrat27": {
       "cell_measures": "area: areacella",
@@ -1097,15 +1097,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 110.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfls",
       "positive": "up",
       "standard_name": "surface_upward_latent_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 1800.0,
-      "valid_min": -400.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hfss": {
       "cell_measures": "area: areacella",
@@ -1121,15 +1121,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 60.0,
-      "ok_min_mean_abs": 5.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfss",
       "positive": "up",
       "standard_name": "surface_upward_sensible_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2000.0,
-      "valid_min": -1000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hur": {
       "cell_measures": "area: areacella",
@@ -1146,15 +1146,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hur",
       "positive": "",
       "standard_name": "relative_humidity",
       "type": "real",
       "units": "%",
-      "valid_max": 105.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "hurs": {
       "cell_measures": "area: areacella",
@@ -1171,15 +1171,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 99.0,
-      "ok_min_mean_abs": 50.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hurs",
       "positive": "",
       "standard_name": "relative_humidity",
       "type": "real",
       "units": "%",
-      "valid_max": 100.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "hursminCrop": {
       "cell_measures": "area: areacella",
@@ -1221,15 +1221,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.01041,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "hus19",
       "positive": "",
       "standard_name": "specific_humidity",
       "type": "real",
       "units": "1",
-      "valid_max": 0.02841,
-      "valid_min": -0.000299
+      "valid_max": "",
+      "valid_min": ""
     },
     "hus27": {
       "cell_measures": "area: areacella",
@@ -1296,15 +1296,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.012,
-      "ok_min_mean_abs": 0.005,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "huss",
       "positive": "",
       "standard_name": "specific_humidity",
       "type": "real",
       "units": "1",
-      "valid_max": 0.03,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "intuadse": {
       "cell_measures": "area: areacella",
@@ -1882,15 +1882,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.00004,
-      "ok_min_mean_abs": 0.000014999999999999999,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "pr",
       "positive": "",
       "standard_name": "precipitation_flux",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.0015,
-      "valid_min": -0.000001
+      "valid_max": "",
+      "valid_min": ""
     },
     "pr17O": {
       "cell_measures": "area: areacella",
@@ -2002,15 +2002,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.00004,
-      "ok_min_mean_abs": 0.000003,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "prc",
       "positive": "",
       "standard_name": "convective_precipitation_flux",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.0015,
-      "valid_min": -0.000001
+      "valid_max": "",
+      "valid_min": ""
     },
     "prhmax": {
       "cell_measures": "area: areacella",
@@ -2074,15 +2074,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.000008,
-      "ok_min_mean_abs": 0.000001,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "prsn",
       "positive": "",
       "standard_name": "snowfall_flux",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.0008,
-      "valid_min": -0.000001
+      "valid_max": "",
+      "valid_min": ""
     },
     "prsn17O": {
       "cell_measures": "area: areacella",
@@ -2170,15 +2170,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 26.0,
-      "ok_min_mean_abs": 12.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "prw",
       "positive": "",
       "standard_name": "atmosphere_mass_content_of_water_vapor",
       "type": "real",
       "units": "kg m-2",
-      "valid_max": 90.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "ps": {
       "cell_measures": "area: areacella",
@@ -2194,15 +2194,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 100000.0,
-      "ok_min_mean_abs": 93000.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "ps",
       "positive": "",
       "standard_name": "surface_air_pressure",
       "type": "real",
       "units": "Pa",
-      "valid_max": 112000.0,
-      "valid_min": 47500.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "psl": {
       "cell_measures": "area: areacella",
@@ -2218,15 +2218,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 106000.0,
-      "ok_min_mean_abs": 96000.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "psl",
       "positive": "",
       "standard_name": "air_pressure_at_mean_sea_level",
       "type": "real",
       "units": "Pa",
-      "valid_max": 109000.0,
-      "valid_min": 91000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rainmxrat27": {
       "cell_measures": "area: areacella",
@@ -2267,15 +2267,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 330.0,
-      "ok_min_mean_abs": 260.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rlds",
       "positive": "down",
       "standard_name": "surface_downwelling_longwave_flux_in_air",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 520.0,
-      "valid_min": 30.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rldscs": {
       "cell_measures": "area: areacella",
@@ -2291,15 +2291,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 310.0,
-      "ok_min_mean_abs": 220.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rldscs",
       "positive": "down",
       "standard_name": "surface_downwelling_longwave_flux_in_air_assuming_clear_sky",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 550.0,
-      "valid_min": 25.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rls": {
       "cell_measures": "area: areacella",
@@ -2339,15 +2339,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 380.0,
-      "ok_min_mean_abs": 320.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rlus",
       "positive": "up",
       "standard_name": "surface_upwelling_longwave_flux_in_air",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 660.0,
-      "valid_min": 43.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rlut": {
       "cell_measures": "area: areacella",
@@ -2363,15 +2363,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 305.0,
-      "ok_min_mean_abs": 205.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rlut",
       "positive": "up",
       "standard_name": "toa_outgoing_longwave_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 385.0,
-      "valid_min": 65.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rlut4co2": {
       "cell_measures": "area: areacella",
@@ -2411,15 +2411,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 270.0,
-      "ok_min_mean_abs": 220.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rlutcs",
       "positive": "up",
       "standard_name": "toa_outgoing_longwave_flux_assuming_clear_sky",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 390.0,
-      "valid_min": 65.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rlutcs4co2": {
       "cell_measures": "area: areacella",
@@ -2459,15 +2459,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 200.0,
-      "ok_min_mean_abs": 120.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rsds",
       "positive": "down",
       "standard_name": "surface_downwelling_shortwave_flux_in_air",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 550.0,
-      "valid_min": -0.1
+      "valid_max": "",
+      "valid_min": ""
     },
     "rsdscs": {
       "cell_measures": "area: areacella",
@@ -2555,15 +2555,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 315.8,
-      "ok_min_mean_abs": 282.6,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rsdt",
       "positive": "down",
       "standard_name": "toa_incoming_shortwave_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 580.4,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rss": {
       "cell_measures": "area: areacella",
@@ -2603,15 +2603,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rsus",
       "positive": "up",
       "standard_name": "surface_upwelling_shortwave_flux_in_air",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 480.0,
-      "valid_min": -0.1
+      "valid_max": "",
+      "valid_min": ""
     },
     "rsuscs": {
       "cell_measures": "area: areacella",
@@ -2627,15 +2627,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rsuscs",
       "positive": "up",
       "standard_name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 480.0,
-      "valid_min": -0.1
+      "valid_max": "",
+      "valid_min": ""
     },
     "rsut": {
       "cell_measures": "area: areacella",
@@ -2651,15 +2651,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 160.0,
-      "ok_min_mean_abs": 60.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rsut",
       "positive": "up",
       "standard_name": "toa_outgoing_shortwave_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 480.0,
-      "valid_min": -0.1
+      "valid_max": "",
+      "valid_min": ""
     },
     "rsut4co2": {
       "cell_measures": "area: areacella",
@@ -2699,15 +2699,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 120.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rsutcs",
       "positive": "up",
       "standard_name": "toa_outgoing_shortwave_flux_assuming_clear_sky",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 480.0,
-      "valid_min": -0.1
+      "valid_max": "",
+      "valid_min": ""
     },
     "rsutcs4co2": {
       "cell_measures": "area: areacella",
@@ -2747,15 +2747,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 150.0,
-      "ok_min_mean_abs": 40.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "rtmt",
       "positive": "down",
       "standard_name": "net_downward_radiative_flux_at_top_of_atmosphere_model",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 250.0,
-      "valid_min": -250.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "sci": {
       "cell_measures": "area: areacella",
@@ -2771,15 +2771,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.9,
-      "ok_min_mean_abs": 0.02,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sci",
       "positive": "",
       "standard_name": "shallow_convection_time_fraction",
       "type": "real",
       "units": "1",
-      "valid_max": 1.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "sconcdust": {
       "cell_measures": "area: areacella",
@@ -2868,15 +2868,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 15.0,
-      "ok_min_mean_abs": 1.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sfcWind",
       "positive": "",
       "standard_name": "wind_speed",
       "type": "real",
       "units": "m s-1",
-      "valid_max": 80.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "sfcWindmax": {
       "cell_measures": "area: areacella",
@@ -3039,15 +3039,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 299.8,
-      "ok_min_mean_abs": 194.3,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "ta",
       "positive": "",
       "standard_name": "air_temperature",
       "type": "real",
       "units": "K",
-      "valid_max": 336.3,
-      "valid_min": 157.1
+      "valid_max": "",
+      "valid_min": ""
     },
     "ta27": {
       "cell_measures": "area: areacella",
@@ -3089,15 +3089,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 295.0,
-      "ok_min_mean_abs": 255.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "tas",
       "positive": "",
       "standard_name": "air_temperature",
       "type": "real",
       "units": "K",
-      "valid_max": 350.0,
-      "valid_min": 170.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "tasmax": {
       "cell_measures": "area: areacella",
@@ -3114,15 +3114,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 300.0,
-      "ok_min_mean_abs": 260.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "tasmax",
       "positive": "",
       "standard_name": "air_temperature",
       "type": "real",
       "units": "K",
-      "valid_max": 355.0,
-      "valid_min": 175.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "tasmaxCrop": {
       "cell_measures": "area: areacella",
@@ -3164,15 +3164,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 290.0,
-      "ok_min_mean_abs": 250.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "tasmin",
       "positive": "",
       "standard_name": "air_temperature",
       "type": "real",
       "units": "K",
-      "valid_max": 345.0,
-      "valid_min": 165.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "tasminCrop": {
       "cell_measures": "area: areacella",
@@ -3213,15 +3213,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.2,
-      "ok_min_mean_abs": 0.01,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "tauu",
       "positive": "down",
       "standard_name": "surface_downward_eastward_stress",
       "type": "real",
       "units": "Pa",
-      "valid_max": 10.0,
-      "valid_min": -10.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "tauv": {
       "cell_measures": "area: areacella",
@@ -3237,15 +3237,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.2,
-      "ok_min_mean_abs": 0.01,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "tauv",
       "positive": "down",
       "standard_name": "surface_downward_northward_stress",
       "type": "real",
       "units": "Pa",
-      "valid_max": 10.0,
-      "valid_min": -10.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "tdps": {
       "cell_measures": "area: areacella",
@@ -3310,15 +3310,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 295.0,
-      "ok_min_mean_abs": 255.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "ts",
       "positive": "",
       "standard_name": "surface_temperature",
       "type": "real",
       "units": "K",
-      "valid_max": 340.0,
-      "valid_min": 170.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "ua19": {
       "cell_measures": "area: areacella",
@@ -3335,15 +3335,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 22.42,
-      "ok_min_mean_abs": 1.101,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "ua19",
       "positive": "",
       "standard_name": "eastward_wind",
       "type": "real",
       "units": "m s-1",
-      "valid_max": 136.6,
-      "valid_min": -68.65
+      "valid_max": "",
+      "valid_min": ""
     },
     "ua27": {
       "cell_measures": "area: areacella",
@@ -3410,15 +3410,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 10.0,
-      "ok_min_mean_abs": 1.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "uas",
       "positive": "",
       "standard_name": "eastward_wind",
       "type": "real",
       "units": "m s-1",
-      "valid_max": 80.0,
-      "valid_min": -80.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "uqint": {
       "cell_measures": "area: areacella",
@@ -3509,15 +3509,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 4.679,
-      "ok_min_mean_abs": 0.9886,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "va19",
       "positive": "",
       "standard_name": "northward_wind",
       "type": "real",
       "units": "m s-1",
-      "valid_max": 69.93,
-      "valid_min": -71.1
+      "valid_max": "",
+      "valid_min": ""
     },
     "va27": {
       "cell_measures": "area: areacella",
@@ -3584,15 +3584,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 10.0,
-      "ok_min_mean_abs": 1.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "vas",
       "positive": "",
       "standard_name": "northward_wind",
       "type": "real",
       "units": "m s-1",
-      "valid_max": 80.0,
-      "valid_min": -80.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "vqint": {
       "cell_measures": "area: areacella",
@@ -3683,15 +3683,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 0.04256,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "wap",
       "positive": "",
       "standard_name": "lagrangian_tendency_of_air_pressure",
       "type": "real",
       "units": "Pa s-1",
-      "valid_max": 2.319,
-      "valid_min": -1.126
+      "valid_max": "",
+      "valid_min": ""
     },
     "zg": {
       "cell_measures": "area: areacella",
@@ -3708,15 +3708,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 32990.0,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "zg",
       "positive": "",
       "standard_name": "geopotential_height",
       "type": "real",
       "units": "m",
-      "valid_max": 34370.0,
-      "valid_min": -719.7
+      "valid_max": "",
+      "valid_min": ""
     },
     "zg27": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_APmon.json
+++ b/Tables/MIP_APmon.json
@@ -977,15 +977,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 1E-9,
-      "ok_min_mean_abs": -1E-11,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "fco2antt",
       "positive": "",
       "standard_name": "tendency_of_atmosphere_mass_content_of_carbon_dioxide_expressed_as_carbon_due_to_anthropogenic_emission",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 2E-7,
-      "valid_min": -1E-7
+      "valid_max": "",
+      "valid_min": ""
     },
     "fco2fos": {
       "cell_measures": "area: areacella",
@@ -1025,8 +1025,8 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 1E-7,
-      "ok_min_mean_abs": 5E-10,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "fco2nat",
       "positive": "",
       "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_emission_from_natural_sources",

--- a/Tables/MIP_APmonLev.json
+++ b/Tables/MIP_APmonLev.json
@@ -12,7 +12,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "APmonLev"
   },
   "variable_entry": {
@@ -31,15 +31,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 26.07,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "cl",
       "positive": "",
       "standard_name": "cloud_area_fraction_in_atmosphere_layer",
       "type": "real",
       "units": "%",
-      "valid_max": 105.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "clc": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_APsubhrPt.json
+++ b/Tables/MIP_APsubhrPt.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "APsubhrPt"
   },
   "variable_entry": {
@@ -27,15 +27,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 110.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfls",
       "positive": "up",
       "standard_name": "surface_upward_latent_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2400.0,
-      "valid_min": -800.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hfss": {
       "cell_measures": "area: areacella",
@@ -51,15 +51,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 60.0,
-      "ok_min_mean_abs": 5.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfss",
       "positive": "up",
       "standard_name": "surface_upward_sensible_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2000.0,
-      "valid_min": -1000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "huss": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_APsubhrPtSite.json
+++ b/Tables/MIP_APsubhrPtSite.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "APsubhrPtSite"
   },
   "variable_entry": {
@@ -166,15 +166,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 90.0,
-      "ok_min_mean_abs": 10.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "clt",
       "positive": "",
       "standard_name": "cloud_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "clw": {
       "cell_measures": "",
@@ -376,15 +376,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 110.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfls",
       "positive": "up",
       "standard_name": "surface_upward_latent_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2400.0,
-      "valid_min": -800.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hfss": {
       "cell_measures": "",
@@ -399,15 +399,15 @@
       "modeling_realm": [
         "atmos"
       ],
-      "ok_max_mean_abs": 60.0,
-      "ok_min_mean_abs": 5.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfss",
       "positive": "up",
       "standard_name": "surface_upward_sensible_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2000.0,
-      "valid_min": -1000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hur": {
       "cell_measures": "",

--- a/Tables/MIP_GIAmon.json
+++ b/Tables/MIP_GIAmon.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "GIAmon"
   },
   "variable_entry": {
@@ -52,15 +52,15 @@
         "landIce",
         "land"
       ],
-      "ok_max_mean_abs": 110.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfls",
       "positive": "up",
       "standard_name": "surface_upward_latent_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 1800.0,
-      "valid_min": -400.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hfss": {
       "cell_measures": "area: areacellg",
@@ -77,15 +77,15 @@
         "landIce",
         "land"
       ],
-      "ok_max_mean_abs": 60.0,
-      "ok_min_mean_abs": 5.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfss",
       "positive": "up",
       "standard_name": "surface_upward_sensible_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2000.0,
-      "valid_min": -1000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "icem": {
       "cell_measures": "area: areacellg",

--- a/Tables/MIP_GIGmon.json
+++ b/Tables/MIP_GIGmon.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "GIGmon"
   },
   "variable_entry": {
@@ -52,15 +52,15 @@
         "landIce",
         "land"
       ],
-      "ok_max_mean_abs": 110.0,
-      "ok_min_mean_abs": 30.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfls",
       "positive": "up",
       "standard_name": "surface_upward_latent_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 1800.0,
-      "valid_min": -400.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "hfss": {
       "cell_measures": "area: areacellg",
@@ -77,15 +77,15 @@
         "landIce",
         "land"
       ],
-      "ok_max_mean_abs": 60.0,
-      "ok_min_mean_abs": 5.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "hfss",
       "positive": "up",
       "standard_name": "surface_upward_sensible_heat_flux",
       "type": "real",
       "units": "W m-2",
-      "valid_max": 2000.0,
-      "valid_min": -1000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "icem": {
       "cell_measures": "area: areacellg",

--- a/Tables/MIP_LImon.json
+++ b/Tables/MIP_LImon.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "LImon"
   },
   "variable_entry": {
@@ -439,15 +439,15 @@
       "modeling_realm": [
         "landIce"
       ],
-      "ok_max_mean_abs": 0.0001,
-      "ok_min_mean_abs": 0.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sbl",
       "positive": "",
       "standard_name": "tendency_of_atmosphere_mass_content_of_water_vapor_due_to_sublimation_of_surface_snow_and_ice",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.001,
-      "valid_min": -0.0005
+      "valid_max": "",
+      "valid_min": ""
     },
     "sblIs": {
       "cell_measures": "area: areacella",
@@ -536,15 +536,15 @@
         "landIce",
         "land"
       ],
-      "ok_max_mean_abs": 78.46,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "snc",
       "positive": "",
       "standard_name": "surface_snow_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 105.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "sncIs": {
       "cell_measures": "area: areacella",
@@ -585,15 +585,15 @@
         "landIce",
         "land"
       ],
-      "ok_max_mean_abs": 4.503,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "snd",
       "positive": "",
       "standard_name": "surface_snow_thickness",
       "type": "real",
       "units": "m",
-      "valid_max": 962.9,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "snicefreezIs": {
       "cell_measures": "area: areacella",
@@ -658,15 +658,15 @@
         "landIce",
         "land"
       ],
-      "ok_max_mean_abs": 0.000006123,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "snm",
       "positive": "",
       "standard_name": "surface_snow_melt_flux",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.0003926,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "snmIs": {
       "cell_measures": "area: areacella",
@@ -707,15 +707,15 @@
         "landIce",
         "land"
       ],
-      "ok_max_mean_abs": 12130.0,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "snw",
       "positive": "",
       "standard_name": "surface_snow_amount",
       "type": "real",
       "units": "kg m-2",
-      "valid_max": 955500.0,
-      "valid_min": -0.007542
+      "valid_max": "",
+      "valid_min": ""
     },
     "sootsn": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_LPfx.json
+++ b/Tables/MIP_LPfx.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "LPfx"
   },
   "variable_entry": {
@@ -151,8 +151,8 @@
       "standard_name": "surface_altitude",
       "type": "real",
       "units": "m",
-      "valid_max": 10000.0,
-      "valid_min": -700.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rootd": {
       "cell_measures": "area: areacella",
@@ -174,8 +174,8 @@
       "standard_name": "root_depth",
       "type": "real",
       "units": "m",
-      "valid_max": 30.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "rootdsl": {
       "cell_measures": "area: areacella",
@@ -245,8 +245,8 @@
       "standard_name": "land_ice_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "slthick": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_LPmon.json
+++ b/Tables/MIP_LPmon.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "LPmon"
   },
   "variable_entry": {
@@ -2792,15 +2792,15 @@
         "land",
         "landIce"
       ],
-      "ok_max_mean_abs": 940.3,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "mrfso",
       "positive": "",
       "standard_name": "soil_frozen_water_content",
       "type": "real",
       "units": "kg m-2",
-      "valid_max": 5763.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "mrlso": {
       "cell_measures": "area: areacella",
@@ -2840,15 +2840,15 @@
       "modeling_realm": [
         "land"
       ],
-      "ok_max_mean_abs": 0.00001874,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "mrro",
       "positive": "",
       "standard_name": "runoff_flux",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.001065,
-      "valid_min": -0.0002019
+      "valid_max": "",
+      "valid_min": ""
     },
     "mrroLut": {
       "cell_measures": "area: areacella",
@@ -2889,15 +2889,15 @@
       "modeling_realm": [
         "land"
       ],
-      "ok_max_mean_abs": 0.00001302,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "mrros",
       "positive": "",
       "standard_name": "surface_runoff_flux",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.0009825,
-      "valid_min": -0.000006802
+      "valid_max": "",
+      "valid_min": ""
     },
     "mrsfl": {
       "cell_measures": "area: areacella",
@@ -2963,15 +2963,15 @@
       "modeling_realm": [
         "land"
       ],
-      "ok_max_mean_abs": 3038.0,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "mrso",
       "positive": "",
       "standard_name": "mass_content_of_water_in_soil",
       "type": "real",
       "units": "kg m-2",
-      "valid_max": 5717.0,
-      "valid_min": -64.17
+      "valid_max": "",
+      "valid_min": ""
     },
     "mrsoLut": {
       "cell_measures": "area: areacella",
@@ -3038,15 +3038,15 @@
       "modeling_realm": [
         "land"
       ],
-      "ok_max_mean_abs": 123.3,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "mrsos",
       "positive": "",
       "standard_name": "mass_content_of_water_in_soil_layer",
       "type": "real",
       "units": "kg m-2",
-      "valid_max": 146.5,
-      "valid_min": -2.008
+      "valid_max": "",
+      "valid_min": ""
     },
     "mrsosLut": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_OPday.json
+++ b/Tables/MIP_OPday.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "OPday"
   },
   "variable_entry": {
@@ -75,15 +75,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 28.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sos",
       "positive": "",
       "standard_name": "sea_surface_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 100.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "sossq": {
       "cell_measures": "area: areacello",
@@ -99,15 +99,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 1600.0,
-      "ok_min_mean_abs": 780.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sossq",
       "positive": "",
       "standard_name": "square_of_sea_surface_salinity",
       "type": "real",
       "units": "1e-06",
-      "valid_max": 10000.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "t20d": {
       "cell_measures": "area: areacello",

--- a/Tables/MIP_OPdec.json
+++ b/Tables/MIP_OPdec.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "OPdec"
   },
   "variable_entry": {
@@ -167,15 +167,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 28.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "soga",
       "positive": "",
       "standard_name": "sea_water_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 80.0,
-      "valid_min": 20.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "sos": {
       "cell_measures": "area: areacello",
@@ -191,15 +191,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 28.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sos",
       "positive": "",
       "standard_name": "sea_surface_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 100.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "sosga": {
       "cell_measures": "",
@@ -213,15 +213,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 1600.0,
-      "ok_min_mean_abs": 780.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sosga",
       "positive": "",
       "standard_name": "sea_surface_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 6400.0,
-      "valid_min": 400.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "tauuo": {
       "cell_measures": "area: areacello",

--- a/Tables/MIP_OPdecLev.json
+++ b/Tables/MIP_OPdecLev.json
@@ -12,7 +12,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "OPdecLev"
   },
   "variable_entry": {
@@ -131,15 +131,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 28.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "so",
       "positive": "",
       "standard_name": "sea_water_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 100.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "thetao": {
       "cell_measures": "area: areacello volume: volcello",

--- a/Tables/MIP_OPmon.json
+++ b/Tables/MIP_OPmon.json
@@ -1392,15 +1392,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 303.5,
-      "ok_min_mean_abs": 272.0,
+      "ok_max_mean_abs": 30.4,
+      "ok_min_mean_abs": -1.1,
       "out_name": "tos",
       "positive": "",
       "standard_name": "sea_surface_temperature",
       "type": "real",
       "units": "degC",
-      "valid_max": 325.2,
-      "valid_min": 257.4
+      "valid_max": 51.2,
+      "valid_min": -15.7
     },
     "tosga": {
       "cell_measures": "",

--- a/Tables/MIP_OPmon.json
+++ b/Tables/MIP_OPmon.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "OPmon"
   },
   "variable_entry": {
@@ -842,15 +842,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 0.00000611,
-      "ok_min_mean_abs": 0.000001449,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "prsn",
       "positive": "",
       "standard_name": "snowfall_flux",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.0002987,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "pso": {
       "cell_measures": "area: areacello",
@@ -1009,15 +1009,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 28.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "soga",
       "positive": "",
       "standard_name": "sea_water_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 80.0,
-      "valid_min": 20.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "somint": {
       "cell_measures": "area: areacello",
@@ -1057,15 +1057,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 28.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sos",
       "positive": "",
       "standard_name": "sea_surface_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 100.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "sosga": {
       "cell_measures": "",
@@ -1079,15 +1079,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 1600.0,
-      "ok_min_mean_abs": 780.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sosga",
       "positive": "",
       "standard_name": "sea_surface_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 6400.0,
-      "valid_min": 400.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "sossq": {
       "cell_measures": "area: areacello",
@@ -1103,15 +1103,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 1600.0,
-      "ok_min_mean_abs": 780.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sossq",
       "positive": "",
       "standard_name": "square_of_sea_surface_salinity",
       "type": "real",
       "units": "1e-06",
-      "valid_max": 10000.0,
-      "valid_min": 0.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "t20d": {
       "cell_measures": "area: areacello",
@@ -1392,15 +1392,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 30.4,
-      "ok_min_mean_abs": -1.1,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "tos",
       "positive": "",
       "standard_name": "sea_surface_temperature",
       "type": "real",
       "units": "degC",
-      "valid_max": 51.2,
-      "valid_min": -15.7
+      "valid_max": "",
+      "valid_min": ""
     },
     "tosga": {
       "cell_measures": "",
@@ -1653,15 +1653,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 0.00006051,
-      "ok_min_mean_abs": 0.00001831,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "wfo",
       "positive": "",
       "standard_name": "water_flux_into_sea_water",
       "type": "real",
       "units": "kg m-2 s-1",
-      "valid_max": 0.03952,
-      "valid_min": -0.005411
+      "valid_max": "",
+      "valid_min": ""
     },
     "wfonocorr": {
       "cell_measures": "area: areacello",
@@ -1701,15 +1701,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 1.572,
-      "ok_min_mean_abs": 0.008384,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "zos",
       "positive": "",
       "standard_name": "sea_surface_height_above_geoid",
       "type": "real",
       "units": "m",
-      "valid_max": 9.575,
-      "valid_min": -13.97
+      "valid_max": "",
+      "valid_min": ""
     },
     "zossq": {
       "cell_measures": "area: areacello",
@@ -1747,15 +1747,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 0.2998,
+      "ok_max_mean_abs": "",
       "ok_min_mean_abs": "",
       "out_name": "zostoga",
       "positive": "",
       "standard_name": "global_average_thermosteric_sea_level_change",
       "type": "real",
       "units": "m",
-      "valid_max": 0.3734,
-      "valid_min": -0.1375
+      "valid_max": "",
+      "valid_min": ""
     }
   }
 }

--- a/Tables/MIP_OPmonLev.json
+++ b/Tables/MIP_OPmonLev.json
@@ -12,7 +12,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "OPmonLev"
   },
   "variable_entry": {
@@ -31,15 +31,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 5000.0,
-      "ok_min_mean_abs": 50.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "agessc",
       "positive": "",
       "standard_name": "sea_water_age_since_surface_contact",
       "type": "real",
       "units": "yr",
-      "valid_max": 20000.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "bigthetao": {
       "cell_measures": "area: areacello volume: volcello",
@@ -1007,15 +1007,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 28.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "so",
       "positive": "",
       "standard_name": "sea_water_salinity",
       "type": "real",
       "units": "0.001",
-      "valid_max": 100.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "sw17O": {
       "cell_measures": "area: areacello volume: volcello",

--- a/Tables/MIP_OPmonZ.json
+++ b/Tables/MIP_OPmonZ.json
@@ -178,7 +178,7 @@
       "standard_name": "northward_ocean_heat_transport_due_to_overturning",
       "type": "real",
       "units": "W",
-      "valid_max": ""E+16,
+      "valid_max": "",
       "valid_min": ""
     },
     "msftmrho": {

--- a/Tables/MIP_OPmonZ.json
+++ b/Tables/MIP_OPmonZ.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "OPmonZ"
   },
   "variable_entry": {
@@ -147,15 +147,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 236400000000000.0,
-      "ok_min_mean_abs": 59100000000000.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "htovgyre",
       "positive": "",
       "standard_name": "northward_ocean_heat_transport_due_to_gyre",
       "type": "real",
       "units": "W",
-      "valid_max": 2691000000000000.0,
-      "valid_min": -1772000000000000.0
+      "valid_max": "",
+      "valid_min": ""
     },
     "htovovrt": {
       "cell_measures": "",
@@ -171,15 +171,15 @@
       "modeling_realm": [
         "ocean"
       ],
-      "ok_max_mean_abs": 815600000000000.0,
-      "ok_min_mean_abs": 203900000000000.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "htovovrt",
       "positive": "",
       "standard_name": "northward_ocean_heat_transport_due_to_overturning",
       "type": "real",
       "units": "W",
-      "valid_max": 1.305E+16,
-      "valid_min": -6263000000000000.0
+      "valid_max": ""E+16,
+      "valid_min": ""
     },
     "msftmrho": {
       "cell_measures": "",

--- a/Tables/MIP_SIday.json
+++ b/Tables/MIP_SIday.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "SIday"
   },
   "variable_entry": {
@@ -28,15 +28,15 @@
       "modeling_realm": [
         "seaIce"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 1.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "siconc",
       "positive": "",
       "standard_name": "sea_ice_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "siconca": {
       "cell_measures": "area: areacella",
@@ -150,15 +150,15 @@
         "seaIce",
         "ocean"
       ],
-      "ok_max_mean_abs": 4.0,
-      "ok_min_mean_abs": 0.05,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sithick",
       "positive": "",
       "standard_name": "sea_ice_thickness",
       "type": "real",
       "units": "m",
-      "valid_max": 200.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "sitimefrac": {
       "cell_measures": "area: areacello",

--- a/Tables/MIP_SImon.json
+++ b/Tables/MIP_SImon.json
@@ -9,7 +9,7 @@
     "int_missing_value": "-999",
     "missing_value": "1e20",
     "product": "model-output",
-    "table_date": "2023-11-16",
+    "table_date": "2024-02-28",
     "table_id": "SImon"
   },
   "variable_entry": {
@@ -167,15 +167,15 @@
       "modeling_realm": [
         "seaIce"
       ],
-      "ok_max_mean_abs": 40.0,
-      "ok_min_mean_abs": 1.0,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "siconc",
       "positive": "",
       "standard_name": "sea_ice_area_fraction",
       "type": "real",
       "units": "%",
-      "valid_max": 100.001,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "siconca": {
       "cell_measures": "area: areacella",
@@ -1730,15 +1730,15 @@
         "seaIce",
         "ocean"
       ],
-      "ok_max_mean_abs": 4.0,
-      "ok_min_mean_abs": 0.05,
+      "ok_max_mean_abs": "",
+      "ok_min_mean_abs": "",
       "out_name": "sithick",
       "positive": "",
       "standard_name": "sea_ice_thickness",
       "type": "real",
       "units": "m",
-      "valid_max": 200.0,
-      "valid_min": -0.001
+      "valid_max": "",
+      "valid_min": ""
     },
     "sitimefrac": {
       "cell_measures": "area: areacello",


### PR DESCRIPTION
Issue must have been a mismatch between the validation limits when I brought these in from the data request.

I've checked all tos entries across tables and none of the other tables have had the limits applied.

As such the only change is to the OPmon table.

Need to ensure that versioning is appropriately applied on release