### PR TITLE
RAMIP: new variables

### DIFF
--- a/Tables/MIP_AEday.json
+++ b/Tables/MIP_AEday.json
@@ -85,6 +85,271 @@
       "valid_max": "",
       "valid_min": ""
     },
+    "mmrbcs": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_elemental_carbon_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Elemental Carbon Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of black carbon aerosol particles in air, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrbcs",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrdusts": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_dust_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Dust Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of dust aerosol particles in air, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrdusts",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrnh4s": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_ammonium_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "NH4 Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of ammonium aerosol particles in air, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrnh4s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrno3s": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_nitrate_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "NO3 Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of nitrate aerosol particles in air, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrno3s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmroas": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_particulate_organic_matter_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Total Organic Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of organic matter particles in air, reported for the lowest model level. We recommend a scale factor of POM=1.4*OC, unless your model has more detailed info available.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmroas",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrpm10s": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_pm10_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "PM10 Mass Mixing Ratio at the surface",
+      "comment": "Mass fraction atmospheric particulate compounds with an aerodynamic diameter of less than or equal to 10 micrometers, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrpm10s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrpm2p5s": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_pm2p5_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "PM2.5 Mass Mixing Ratio at the surface",
+      "comment": "Mass fraction atmospheric particulate compounds with an aerodynamic diameter of less than or equal to 2.5 micrometers, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrpm2p5s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrso4s": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_sulfate_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Aerosol Sulfate Mass Mixing Ratio at the surface",
+      "comment": "Dry mass of sulfate (SO4) in aerosol particles as a fraction of air mass, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrso4s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrsoas": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_secondary_particulate_organic_matter_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Secondary Organic Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Mass fraction in the atmosphere of secondary organic aerosols (particulate organic matter formed within the atmosphere from gaseous precursors; dry mass, reported for the lowest model level.).",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrsoas",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrsss": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_sea_salt_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Sea-Salt Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Mass fraction in the atmosphere of sea salt aerosol (dry mass), reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrsss",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "o33": {
+      "frequency": "day",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mole_fraction_of_ozone_in_air",
+      "units": "mol mol-1",
+      "cell_methods": "time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Mole Fraction of O3",
+      "comment": "Mole fraction is used in the construction mole_fraction_of_X_in_Y, where X is a material constituent of Y.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "plev3",
+        "time"
+      ],
+      "out_name": "o33",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
     "od550aer": {
       "cell_measures": "area: areacella",
       "cell_methods": "area: time: mean",

--- a/Tables/MIP_AEday.json
+++ b/Tables/MIP_AEday.json
@@ -90,7 +90,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_elemental_carbon_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_elemental_carbon_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -114,7 +114,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_dust_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_dust_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -138,7 +138,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_ammonium_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_ammonium_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -162,7 +162,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_nitrate_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_nitrate_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -186,7 +186,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_particulate_organic_matter_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_particulate_organic_matter_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -210,7 +210,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_pm10_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_pm10_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -234,7 +234,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_pm2p5_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_pm2p5_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -258,7 +258,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_sulfate_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_sulfate_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -282,7 +282,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_secondary_particulate_organic_matter_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_secondary_particulate_organic_matter_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -306,7 +306,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_sea_salt_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_sea_salt_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",

--- a/Tables/MIP_AEmon.json
+++ b/Tables/MIP_AEmon.json
@@ -91,7 +91,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "cloud_condensation_nuclei_concentration_at_0point2_percent_supersaturation",
+      "standard_name": "",
       "units": "cm-3",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -116,7 +116,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "cloud_condensation_nuclei_concentration_at_1_percent_supersaturation",
+      "standard_name": "",
       "units": "cm-3",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -189,7 +189,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "tendency_of_atmosphere_mass_content_of_ammonium_dry_aerosol_particles_due_to_net_chemical_production",
+      "standard_name": "",
       "units": "kg m-2 s-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -213,7 +213,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "tendency_of_atmosphere_mass_content_of_nitrate_dry_aerosol_particles_due_to_net_chemical_production",
+      "standard_name": "",
       "units": "kg m-2 s-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -357,7 +357,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "minus_tendency_of_atmosphere_mass_content_of_nitric_acid_due_to_dry_deposition",
+      "standard_name": "",
       "units": "kg m-2 s-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -981,7 +981,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_elemental_carbon_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_elemental_carbon_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1005,7 +1005,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_dust_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_dust_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1029,7 +1029,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_ammonium_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_ammonium_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1077,7 +1077,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_nitrate_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_nitrate_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1101,7 +1101,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_particulate_organic_matter_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_particulate_organic_matter_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1125,7 +1125,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_pm10_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_pm10_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1149,7 +1149,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_pm2p5_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_pm2p5_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1173,7 +1173,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_sulfate_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_sulfate_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1197,7 +1197,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_secondary_particulate_organic_matter_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_secondary_particulate_organic_matter_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1221,7 +1221,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "mass_fraction_of_sea_salt_dry_aerosol_particles_at_the_surface",
+      "standard_name": "mass_fraction_of_sea_salt_dry_aerosol_particles",
       "units": "kg kg-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",
@@ -1979,7 +1979,7 @@
       "modeling_realm": [
         "aerosol"
       ],
-      "standard_name": "minus_tendency_of_atmosphere_mass_content_of_nitric_acid_due_to_wet_deposition",
+      "standard_name": "",
       "units": "kg m-2 s-1",
       "cell_methods": "area: time: mean",
       "cell_measures": "area: areacella",

--- a/Tables/MIP_AEmon.json
+++ b/Tables/MIP_AEmon.json
@@ -86,6 +86,56 @@
       "valid_max": "",
       "valid_min": ""
     },
+    "ccn02": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "cloud_condensation_nuclei_concentration_at_0point2_percent_supersaturation",
+      "units": "cm-3",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Cloud Condensation Nuclei concentration at 0.2 percent supersaturation",
+      "comment": "Based on aerosol chemical composition and size",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "alevel",
+        "time"
+      ],
+      "out_name": "ccn02",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "ccn1": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "cloud_condensation_nuclei_concentration_at_1_percent_supersaturation",
+      "units": "cm-3",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Cloud Condensation Nuclei at 1 percent supersaturation",
+      "comment": "Based on aerosol chemical composition and size",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "alevel",
+        "time"
+      ],
+      "out_name": "ccn1",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
     "chepasoa": {
       "cell_measures": "area: areacella",
       "cell_methods": "area: time: mean",
@@ -133,6 +183,54 @@
       "units": "kg m-2 s-1",
       "valid_max": "",
       "valid_min": ""
+    },
+    "chepnh4": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "tendency_of_atmosphere_mass_content_of_ammonium_dry_aerosol_particles_due_to_net_chemical_production",
+      "units": "kg m-2 s-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Chemical Production rate of NH4",
+      "comment": "",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "chepnh4",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "chepno3": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "tendency_of_atmosphere_mass_content_of_nitrate_dry_aerosol_particles_due_to_net_chemical_production",
+      "units": "kg m-2 s-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Chemical Production rate of NO3",
+      "comment": "Defined as net production. Also includes N2O5 conversion",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "chepno3",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
     },
     "cltc": {
       "cell_measures": "area: areacella",
@@ -253,6 +351,30 @@
       "units": "kg m-2 s-1",
       "valid_max": "",
       "valid_min": ""
+    },
+    "dryhno3": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "minus_tendency_of_atmosphere_mass_content_of_nitric_acid_due_to_dry_deposition",
+      "units": "kg m-2 s-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Dry Deposition Rate of HNO3",
+      "comment": "Dry Deposition includes gravitational settling and turbulent deposition",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "dryhno3",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
     },
     "drynh3": {
       "cell_measures": "area: areacella",
@@ -854,6 +976,78 @@
       "valid_max": "",
       "valid_min": ""
     },
+    "mmrbcs": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_elemental_carbon_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Elemental Carbon Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of black carbon aerosol particles in air, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrbcs",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrdusts": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_dust_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Dust Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of dust aerosol particles in air, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrdusts",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrnh4s": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_ammonium_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "NH4 Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of ammonium aerosol particles in air, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrnh4s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
     "mmrno3": {
       "cell_measures": "area: areacella",
       "cell_methods": "area: time: mean",
@@ -877,6 +1071,174 @@
       "units": "kg kg-1",
       "valid_max": "",
       "valid_min": ""
+    },
+    "mmrno3s": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_nitrate_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "NO3 Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of nitrate aerosol particles in air, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrno3s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmroas": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_particulate_organic_matter_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Total Organic Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Dry mass fraction of organic matter particles in air, reported for the lowest model level. We recommend a scale factor of POM=1.4*OC, unless your model has more detailed info available.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmroas",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrpm10s": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_pm10_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "PM10 Mass Mixing Ratio at the surface",
+      "comment": "Mass fraction atmospheric particulate compounds with an aerodynamic diameter of less than or equal to 10 micrometers, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrpm10s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrpm2p5s": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_pm2p5_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "PM2.5 Mass Mixing Ratio at the surface",
+      "comment": "Mass fraction atmospheric particulate compounds with an aerodynamic diameter of less than or equal to 2.5 micrometers, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrpm2p5s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrso4s": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_sulfate_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Aerosol Sulfate Mass Mixing Ratio at the surface",
+      "comment": "Dry mass of sulfate (SO4) in aerosol particles as a fraction of air mass, reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrso4s",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrsoas": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_secondary_particulate_organic_matter_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Secondary Organic Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Mass fraction in the atmosphere of secondary organic aerosols (particulate organic matter formed within the atmosphere from gaseous precursors; dry mass, reported for the lowest model level.).",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrsoas",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
+    "mmrsss": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "mass_fraction_of_sea_salt_dry_aerosol_particles_at_the_surface",
+      "units": "kg kg-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Sea-Salt Aerosol Mass Mixing Ratio at the surface",
+      "comment": "Mass fraction in the atmosphere of sea salt aerosol (dry mass), reported for the lowest model level.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "mmrsss",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
     },
     "od440aer": {
       "cell_measures": "area: areacella",
@@ -1611,6 +1973,30 @@
       "units": "kg m-2 s-1",
       "valid_max": "",
       "valid_min": ""
+    },
+    "wethno3": {
+      "frequency": "mon",
+      "modeling_realm": [
+        "aerosol"
+      ],
+      "standard_name": "minus_tendency_of_atmosphere_mass_content_of_nitric_acid_due_to_wet_deposition",
+      "units": "kg m-2 s-1",
+      "cell_methods": "area: time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Wet Deposition Rate of HNO3",
+      "comment": "Surface deposition rate of nitric acid (HNO3) due to wet processes",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "time"
+      ],
+      "out_name": "wethno3",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
     },
     "wetnh3": {
       "cell_measures": "area: areacella",

--- a/Tables/MIP_APday.json
+++ b/Tables/MIP_APday.json
@@ -794,6 +794,31 @@
       "valid_max": "",
       "valid_min": ""
     },
+    "hus3": {
+      "frequency": "day",
+      "modeling_realm": [
+        "atmos"
+      ],
+      "standard_name": "specific_humidity",
+      "units": "1",
+      "cell_methods": "time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Specific Humidity",
+      "comment": "Specific humidity is the mass fraction of water vapor in (moist) air.",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "plev3",
+        "time"
+      ],
+      "out_name": "hus3",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
     "hus8": {
       "cell_measures": "area: areacella",
       "cell_methods": "time: mean",
@@ -2615,6 +2640,31 @@
       "valid_max": "",
       "valid_min": ""
     },
+    "ua3": {
+      "frequency": "day",
+      "modeling_realm": [
+        "atmos"
+      ],
+      "standard_name": "eastward_wind",
+      "units": "m s-1",
+      "cell_methods": "time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Eastward Wind",
+      "comment": "Zonal wind (positive in a eastward direction).",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "plev3",
+        "time"
+      ],
+      "out_name": "ua3",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
+    },
     "ua8": {
       "cell_measures": "area: areacella",
       "cell_methods": "time: mean",
@@ -2689,6 +2739,31 @@
       "units": "m s-1",
       "valid_max": "",
       "valid_min": ""
+    },
+    "va3": {
+      "frequency": "day",
+      "modeling_realm": [
+        "atmos"
+      ],
+      "standard_name": "northward_wind",
+      "units": "m s-1",
+      "cell_methods": "time: mean",
+      "cell_measures": "area: areacella",
+      "long_name": "Northward Wind",
+      "comment": "Meridional wind (positive in a northward direction).",
+      "dimensions": [
+        "longitude",
+        "latitude",
+        "plev3",
+        "time"
+      ],
+      "out_name": "va3",
+      "type": "real",
+      "positive": "",
+      "valid_min": "",
+      "valid_max": "",
+      "ok_min_mean_abs": "",
+      "ok_max_mean_abs": ""
     },
     "va8": {
       "cell_measures": "area: areacella",


### PR DESCRIPTION
These are RAMIP variables copied over from the RAMIPday and RAMIPmon mip tables [here](https://github.com/ramipaerosols/RAMIP/tree/RAMIP-cmor-tables)

Modifications to the RAMIP tables:
* Daily ozone variable on 3 levels changed to have modeling_realm aerosol for consistency with other ozone variables 
* CF Standard names:
   * truncated several standard names which had `_at_the_surface` appended -- these are not in the latest (v86) release of the CF standard names and I don't see a proposal for adding them.
   * removed standard names which have not yet completed their registration, i.e. are not part of the latest CF standard names release -- I believe these are not far from being included, but this is not available yet.

@ramipaerosols, please check that you are happy with these changes